### PR TITLE
fix(yaml): enable to extract a value from a list of yaml.MapSlice

### DIFF
--- a/extractor/yaml/example_yaml_test.go
+++ b/extractor/yaml/example_yaml_test.go
@@ -1,0 +1,30 @@
+package yaml_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/goccy/go-yaml"
+	"github.com/zoncoen/query-go"
+
+	yamlextractor "github.com/zoncoen/query-go/extractor/yaml"
+)
+
+func ExampleMapSliceExtractFunc() {
+	b := []byte(`- foo: bar`)
+	var v interface{}
+	if err := yaml.UnmarshalWithOptions(b, &v, yaml.UseOrderedMap()); err != nil {
+		log.Fatal(err)
+	}
+
+	q := query.New(
+		query.CustomExtractFunc(yamlextractor.MapSliceExtractFunc(true)),
+	).Index(0).Key("FOO")
+	got, err := q.Extract(v)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(got)
+	// Output:
+	// bar
+}

--- a/extractor/yaml/yaml.go
+++ b/extractor/yaml/yaml.go
@@ -1,3 +1,6 @@
+/*
+Package yaml provides a function to extract values from yaml.MapSlice.
+*/
 package yaml
 
 import (
@@ -9,14 +12,22 @@ import (
 	"github.com/zoncoen/query-go"
 )
 
-var (
-	mapSliceType = reflect.TypeOf(yaml.MapSlice{})
-)
+var mapSliceType = reflect.TypeOf(yaml.MapSlice{})
 
-// MapSliceExtractFunc is a function for query.CustomExtractFunc option.
+// MapSliceExtractFunc is a function for query.CustomExtractFunc option to extract values from yaml.MapSlice.
 func MapSliceExtractFunc(caseInsensitive bool) func(query.ExtractFunc) query.ExtractFunc {
 	return func(f query.ExtractFunc) query.ExtractFunc {
-		return func(v reflect.Value) (reflect.Value, bool) {
+		return func(in reflect.Value) (reflect.Value, bool) {
+			v := in
+			for {
+				if v.IsValid() {
+					if k := v.Kind(); k == reflect.Interface || k == reflect.Pointer {
+						v = v.Elem()
+						continue
+					}
+				}
+				break
+			}
 			switch v.Kind() {
 			case reflect.Slice:
 				if v.Type() == mapSliceType {
@@ -31,7 +42,7 @@ func MapSliceExtractFunc(caseInsensitive bool) func(query.ExtractFunc) query.Ext
 					}
 				}
 			}
-			return f(v)
+			return f(in)
 		}
 	}
 }

--- a/extractor/yaml/yaml_test.go
+++ b/extractor/yaml/yaml_test.go
@@ -40,11 +40,37 @@ func TestMapSliceExtractFunc(t *testing.T) {
 				},
 				expect: "aaa",
 			},
+			"[]interface{yaml.MapSlice}": {
+				query: query.New(
+					query.CustomExtractFunc(MapSliceExtractFunc(false)),
+				).Index(0).Key("foo"),
+				v: []interface{}{
+					yaml.MapSlice{
+						yaml.MapItem{
+							Key:   "foo",
+							Value: "aaa",
+						},
+					},
+				},
+				expect: "aaa",
+			},
+			"*yaml.MapSlice": {
+				query: query.New(
+					query.CustomExtractFunc(MapSliceExtractFunc(false)),
+				).Key("foo"),
+				v: &yaml.MapSlice{
+					yaml.MapItem{
+						Key:   "foo",
+						Value: "aaa",
+					},
+				},
+				expect: "aaa",
+			},
 			"not yaml.MapSlice": {
 				query: query.New(
 					query.CustomExtractFunc(MapSliceExtractFunc(false)),
 				).Index(1),
-				v:      []int{1, 2},
+				v:      []interface{}{1, 2},
 				expect: 2,
 			},
 			"not slice": {


### PR DESCRIPTION
The function must call `Elem` method to get the concrete type of the value that the interface contains or that the pointer points to.