### PR TITLE
feat: add CustomIsInlineStructFieldFunc

### DIFF
--- a/option.go
+++ b/option.go
@@ -15,7 +15,7 @@ func CaseInsensitive() Option {
 // ExtractByStructTag returns the Option to allow extracting by struct tag.
 func ExtractByStructTag(tagNames ...string) Option {
 	return func(q *Query) {
-		q.structTags = tagNames
+		q.structTags = append(q.structTags, tagNames...)
 	}
 }
 
@@ -33,5 +33,12 @@ func CustomExtractFunc(f func(ExtractFunc) ExtractFunc) Option {
 func CustomStructFieldNameGetter(f func(f reflect.StructField) string) Option {
 	return func(q *Query) {
 		q.customStructFieldNameGetter = f
+	}
+}
+
+// CustomIsInlineStructFieldFunc returns the Option to customize the behavior of extractors.
+func CustomIsInlineStructFieldFunc(f func(reflect.StructField) bool) Option {
+	return func(q *Query) {
+		q.customIsInlineFuncs = append(q.customIsInlineFuncs, f)
 	}
 }

--- a/query.go
+++ b/query.go
@@ -14,6 +14,7 @@ type Query struct {
 	structTags                  []string
 	customExtractFuncs          []func(ExtractFunc) ExtractFunc
 	customStructFieldNameGetter func(f reflect.StructField) string
+	customIsInlineFuncs         []func(reflect.StructField) bool
 	hasExplicitRoot             bool
 }
 
@@ -48,6 +49,7 @@ func (q Query) Key(k string) *Query {
 		caseInsensitive: q.caseInsensitive,
 		structTags:      q.structTags,
 		fieldNameGetter: q.customStructFieldNameGetter,
+		isInlineFuncs:   q.customIsInlineFuncs,
 	})
 }
 


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|                        | [main](https://github.com/zoncoen/query-go/tree/main) ([10914ca](https://github.com/zoncoen/query-go/commit/10914ca581126ee29130749c1194e007a5ff2bff)) | [#53](https://github.com/zoncoen/query-go/pull/53) ([a7b1bfd](https://github.com/zoncoen/query-go/commit/a7b1bfdd8e422c84f1e17c7409de344232560d9b)) |  +/-  |
|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**           |                                                                                                                                                  94.3% |                                                                                                                                               93.7% | -0.6% |
| **Code to Test Ratio** |                                                                                                                                                  1:1.7 |                                                                                                                                               1:1.7 |  -0.0 |

<details>

<summary>Details</summary>

``` diff
  |                    | main (10914ca) | #53 (a7b1bfd) |  +/-  |
  |--------------------|----------------|---------------|-------|
- | Coverage           |          94.3% |         93.7% | -0.6% |
  |   Files            |             12 |            12 |     0 |
  |   Lines            |            528 |           542 |   +14 |
+ |   Covered          |            498 |           508 |   +10 |
- | Code to Test Ratio |          1:1.7 |         1:1.7 |  -0.0 |
  |   Code             |            753 |           772 |   +19 |
+ |   Test             |           1309 |          1341 |   +32 |
```

</details>


### Code coverage of files in pull request scope (98.2% → 96.2%)

|                                                  Files                                                   | Coverage |  +/-   |
|----------------------------------------------------------------------------------------------------------|---------:|-------:|
| [key.go](https://github.com/zoncoen/query-go/blob/18f9bfb7e179e706379a168c7c9af5956d64c129/key.go)       | 97.1%    | +0.3%  |
| [option.go](https://github.com/zoncoen/query-go/blob/18f9bfb7e179e706379a168c7c9af5956d64c129/option.go) | 80.0%    | -20.0% |
| [query.go](https://github.com/zoncoen/query-go/blob/18f9bfb7e179e706379a168c7c9af5956d64c129/query.go)   | 100.0%   | 0.0%   |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
