### PR TITLE
fix: apply custom extract funcs even if the field is inline

### DIFF
--- a/query.go
+++ b/query.go
@@ -45,11 +45,12 @@ func (q Query) Root() *Query {
 // Key is shorthand method to create Key and appends it.
 func (q Query) Key(k string) *Query {
 	return q.Append(&Key{
-		key:             k,
-		caseInsensitive: q.caseInsensitive,
-		structTags:      q.structTags,
-		fieldNameGetter: q.customStructFieldNameGetter,
-		isInlineFuncs:   q.customIsInlineFuncs,
+		key:                k,
+		caseInsensitive:    q.caseInsensitive,
+		structTags:         q.structTags,
+		customExtractFuncs: q.customExtractFuncs,
+		fieldNameGetter:    q.customStructFieldNameGetter,
+		isInlineFuncs:      q.customIsInlineFuncs,
 	})
 }
 


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|                        | [main](https://github.com/zoncoen/query-go/tree/main) ([20ae25e](https://github.com/zoncoen/query-go/commit/20ae25e4872fd55064586d1b8b5d9a7fd038ec36)) | [#61](https://github.com/zoncoen/query-go/pull/61) ([a5bde62](https://github.com/zoncoen/query-go/commit/a5bde62748a0ba6b6876429836432cd39e4e7d3d)) |  +/-  |
|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**           |                                                                                                                                                  93.7% |                                                                                                                                               93.8% | +0.1% |
| **Code to Test Ratio** |                                                                                                                                                  1:1.4 |                                                                                                                                               1:1.4 |  +0.0 |

<details>

<summary>Details</summary>

``` diff
  |                    | main (20ae25e) | #61 (a5bde62) |  +/-  |
  |--------------------|----------------|---------------|-------|
+ | Coverage           |          93.7% |         93.8% | +0.1% |
  |   Files            |             13 |            13 |     0 |
  |   Lines            |            555 |           561 |    +6 |
+ |   Covered          |            520 |           526 |    +6 |
+ | Code to Test Ratio |          1:1.4 |         1:1.4 |  +0.0 |
  |   Code             |           1136 |          1144 |    +8 |
+ |   Test             |           1545 |          1575 |   +30 |
```

</details>


### Code coverage of files in pull request scope (98.2% → 98.3%)

|                                                 Files                                                  | Coverage |  +/-  |
|--------------------------------------------------------------------------------------------------------|---------:|------:|
| [key.go](https://github.com/zoncoen/query-go/blob/c42c50d61fed2b6756874c31e53a5891f1288a4f/key.go)     | 97.3%    | +0.1% |
| [query.go](https://github.com/zoncoen/query-go/blob/c42c50d61fed2b6756874c31e53a5891f1288a4f/query.go) | 100.0%   | 0.0%  |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
