### PR TITLE
feat: add IndexExtractorContext and Query.ExtractContext

### DIFF
--- a/index.go
+++ b/index.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -13,6 +14,14 @@ type IndexExtractor interface {
 	ExtractByIndex(index int) (interface{}, bool)
 }
 
+// IndexExtractorContext is the interface that wraps the ExtractByIndex method.
+//
+// ExtractByIndex extracts the value by index.
+// It reports whether the index is found and returns the found value.
+type IndexExtractorContext interface {
+	ExtractByIndex(ctx context.Context, index int) (any, bool)
+}
+
 // Index represents an extractor to access the value by index.
 type Index struct {
 	index int
@@ -23,7 +32,20 @@ type Index struct {
 //
 // If v implements the IndexExtractor interface, this method extracts by calling v.ExtractByIndex.
 func (e *Index) Extract(v reflect.Value) (reflect.Value, bool) {
+	return e.ExtractContext(context.Background(), v)
+}
+
+// ExtractContext extracts the value from v by index, passing ctx to a
+// context-aware extractor if v implements one.
+//
+// If v implements the IndexExtractorContext interface, this method extracts by
+// calling v.ExtractByIndex with ctx; otherwise it falls back to IndexExtractor.
+func (e *Index) ExtractContext(ctx context.Context, v reflect.Value) (reflect.Value, bool) {
 	if v.IsValid() {
+		if i, ok := v.Interface().(IndexExtractorContext); ok {
+			x, ok := i.ExtractByIndex(ctx, e.index)
+			return reflect.ValueOf(x), ok
+		}
 		if i, ok := v.Interface().(IndexExtractor); ok {
 			x, ok := i.ExtractByIndex(e.index)
 			return reflect.ValueOf(x), ok

--- a/index_context_test.go
+++ b/index_context_test.go
@@ -1,0 +1,74 @@
+package query
+
+import (
+	"context"
+	"testing"
+)
+
+type ctxKey struct{}
+
+// indexExtractorContext records the context it receives and returns a value
+// derived from it, to verify the caller's context is propagated.
+type indexExtractorContext struct {
+	gotCtx context.Context
+}
+
+func (e *indexExtractorContext) ExtractByIndex(ctx context.Context, _ int) (any, bool) {
+	e.gotCtx = ctx
+	v, _ := ctx.Value(ctxKey{}).(string)
+	return v, true
+}
+
+func TestIndex_ExtractContext(t *testing.T) {
+	e := &indexExtractorContext{}
+	q := New().Index(0)
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "from-caller")
+	got, err := q.ExtractContext(ctx, e)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if got != "from-caller" {
+		t.Fatalf("expected propagated context value but got %v", got)
+	}
+	if e.gotCtx == nil {
+		t.Fatal("expected the extractor to receive a context")
+	}
+}
+
+func TestIndex_Extract_FallsBackToBackground(t *testing.T) {
+	e := &indexExtractorContext{}
+	q := New().Index(0)
+
+	// The context-less Extract must still reach IndexExtractorContext with a
+	// background context, preserving behavior for callers that don't pass one.
+	if _, err := q.Extract(e); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if e.gotCtx == nil {
+		t.Fatal("expected the extractor to receive a background context")
+	}
+	if e.gotCtx.Value(ctxKey{}) != nil {
+		t.Fatal("expected a background context with no caller values")
+	}
+}
+
+// plainIndexExtractor only implements the context-less interface.
+type plainIndexExtractor struct{ called bool }
+
+func (e *plainIndexExtractor) ExtractByIndex(_ int) (interface{}, bool) {
+	e.called = true
+	return "plain", true
+}
+
+func TestIndex_ExtractContext_FallsBackToPlainExtractor(t *testing.T) {
+	e := &plainIndexExtractor{}
+	q := New().Index(0)
+	got, err := q.ExtractContext(context.Background(), e)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !e.called || got != "plain" {
+		t.Fatalf("expected plain IndexExtractor to be used, got %v (called=%v)", got, e.called)
+	}
+}

--- a/key.go
+++ b/key.go
@@ -37,10 +37,18 @@ type Key struct {
 //
 // If v implements the KeyExtractor interface, this method extracts by calling v.ExtractByKey.
 func (e *Key) Extract(v reflect.Value) (reflect.Value, bool) {
+	return e.ExtractContext(context.Background(), v)
+}
+
+// ExtractContext extracts the value from v by key, passing ctx (extended
+// with the query options) to a context-aware extractor if v implements one.
+//
+// If v implements the KeyExtractorContext interface, this method extracts by
+// calling v.ExtractByKey with ctx; otherwise it falls back to KeyExtractor.
+func (e *Key) ExtractContext(ctx context.Context, v reflect.Value) (reflect.Value, bool) {
 	if v.IsValid() {
 		if i, ok := v.Interface().(KeyExtractorContext); ok {
-			ctx := withCaseInsensitive(context.Background(), e.caseInsensitive)
-			x, ok := i.ExtractByKey(ctx, e.key)
+			x, ok := i.ExtractByKey(withCaseInsensitive(ctx, e.caseInsensitive), e.key)
 			return reflect.ValueOf(x), ok
 		}
 		if i, ok := v.Interface().(KeyExtractor); ok {

--- a/query.go
+++ b/query.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"context"
 	"reflect"
 	"strings"
 
@@ -61,12 +62,30 @@ func (q Query) Index(i int) *Query {
 
 // Extract extracts the value by q from target.
 func (q *Query) Extract(target interface{}) (interface{}, error) {
+	return q.ExtractContext(context.Background(), target)
+}
+
+// contextExtractor is implemented by extractors that can use a context.
+type contextExtractor interface {
+	ExtractContext(ctx context.Context, v reflect.Value) (reflect.Value, bool)
+}
+
+// ExtractContext extracts the value by q from target, passing ctx to each
+// extractor that supports it (e.g. a value implementing KeyExtractorContext or
+// IndexExtractorContext). Extractors that are not context-aware behave exactly
+// as in Extract.
+func (q *Query) ExtractContext(ctx context.Context, target interface{}) (interface{}, error) {
 	if q == nil || len(q.extractors) == 0 {
 		return target, nil
 	}
 	v := reflect.ValueOf(target)
 	for _, e := range q.extractors {
 		f := e.Extract
+		if ce, ok := e.(contextExtractor); ok {
+			f = func(v reflect.Value) (reflect.Value, bool) {
+				return ce.ExtractContext(ctx, v)
+			}
+		}
 		for i := len(q.customExtractFuncs) - 1; i >= 0; i-- {
 			f = q.customExtractFuncs[i](f)
 		}


### PR DESCRIPTION
## Summary

Adds a context-aware index extractor, symmetric with the existing `KeyExtractorContext`, and a `Query.ExtractContext` entry point that propagates the caller's context to context-aware extractors.

## Motivation

`KeyExtractorContext` already lets a key extractor receive a `context.Context`, but there was no equivalent for index extraction, and `Query.Extract` had no way to pass a caller-supplied context through to extractors at all (it synthesized `context.Background()` internally). This makes it impossible for a value implementing a blocking/streaming extractor to observe the caller's deadline or cancellation when accessed by index.

## Changes

- Add `IndexExtractorContext` interface (`ExtractByIndex(ctx context.Context, index int) (any, bool)`), mirroring `KeyExtractorContext`.
- Add `Query.ExtractContext(ctx, target)`; `Index`/`Key` gain `ExtractContext` and `Query.Extract` / `Index.Extract` / `Key.Extract` delegate to it with `context.Background()`.
- Naming follows the existing `*Context` suffix (`KeyExtractorContext`, `IndexExtractorContext`) and the Go stdlib convention (`QueryContext`, `ExecContext`).

## Compatibility

Backward compatible: the context-less `Extract` methods delegate to the context variants with `context.Background()`, preserving existing behavior. Context-unaware extractors are unaffected.
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio |
|---------:|-------------------:|
| 93.9%    | 1:1.4              |


### Code coverage of files in pull request scope (98.6%)

|                                                 Files                                                  | Coverage |
|--------------------------------------------------------------------------------------------------------|---------:|
| [index.go](https://github.com/zoncoen/query-go/blob/7ffa8f375d7b40ec0dc3d5b1c0845ed8579c3933/index.go) | 100.0%   |
| [key.go](https://github.com/zoncoen/query-go/blob/7ffa8f375d7b40ec0dc3d5b1c0845ed8579c3933/key.go)     | 97.3%    |
| [query.go](https://github.com/zoncoen/query-go/blob/7ffa8f375d7b40ec0dc3d5b1c0845ed8579c3933/query.go) | 100.0%   |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
